### PR TITLE
[HOTFIX] preprocess glossary in init and set to save lowercased keys

### DIFF
--- a/faqt/model/faq_matching/keyed_vectors_scoring.py
+++ b/faqt/model/faq_matching/keyed_vectors_scoring.py
@@ -28,9 +28,10 @@ class KeyedVectorsScorerBase(ABC):
 
     glossary: Dict[str, Dict[str, float]], optional
         Custom contextualization glossary. Words to replace are keys; their
-        values
-        must be dictionaries with (replacement words : weight) as key-value
-        pairs
+        values must be dictionaries with (replacement words : weight) as key-value
+        pairs. All keys will be turned into its lowercase form. When looking up a word
+        in the glossary, the lowercased token will be looked up. If a token is not found
+        in the glossary, it will be left as is.
 
     hunspell: Hunspell, optional
         Optional instance of the hunspell spell checker.
@@ -86,7 +87,7 @@ class KeyedVectorsScorerBase(ABC):
             tokenizer = word_tokenize
 
         self.tokenizer = tokenizer
-        self.glossary = glossary.copy()
+        self.glossary = preprocess_glossary(glossary)
         self.hunspell = hunspell
         self.tags_guiding_typos = tags_guiding_typos.copy()
 
@@ -109,7 +110,7 @@ class KeyedVectorsScorerBase(ABC):
 
     def set_glossary(self, glossary):
         """Set glossary"""
-        self.glossary = glossary
+        self.glossary = preprocess_glossary(glossary)
 
     def set_tokenizer(self, tokenizer):
         """Set tokenizer"""
@@ -570,6 +571,24 @@ class WMDScorer(KeyedVectorsScorerBase):
         result = {"overall_scores": scores}
 
         return result
+
+
+def preprocess_glossary(glossary):
+    """Preprocess glossary for use in `model_search_word` and `model_search`.
+    Currently only lowercases keys.
+
+    Parameters
+    ----------
+    glossary : Dict
+        Glossary to preprocess.
+
+    Returns
+    -------
+    Dict
+        Preprocessed glossary
+    """
+    lowercased_keys = {k.lower(): v for k, v in glossary.items()}
+    return lowercased_keys
 
 
 def model_search_word(

--- a/tests/test_models/test_keyed_vectors_scoring.py
+++ b/tests/test_models/test_keyed_vectors_scoring.py
@@ -275,6 +275,27 @@ class TestKeyedVectorsScorers:
             np.asarray(content_weights) / sum(content_weights),
         )
 
+    @pytest.mark.parametrize(
+        "model_class",
+        [StepwiseKeyedVectorsScorer, WMDScorer],
+    )
+    def test_glossary_keys_are_lowercased_during_init(self, model_class, w2v_model):
+        model = model_class(w2v_model, glossary={"TEST": "test"})
+
+        for key in model.glossary:
+            assert key.islower()
+
+    @pytest.mark.parametrize(
+        "model_name",
+        ["stepwise_basic_model", "wmd_basic_model"],
+    )
+    def test_glossary_keys_are_lowercased_after_set(self, model_name, request):
+        model = request.getfixturevalue(model_name)
+        model.set_glossary({"TEST": "test"})
+
+        for key in model.glossary:
+            assert key.islower()
+
 
 class TestStepwiseKeyedVectorScorer:
     @pytest.mark.parametrize(


### PR DESCRIPTION
Background:
- With word embeddings (keyed vectors) we sometimes want to map the vector of the uppercase word to the vector of the lowercase word
- e.g. in Google New Embeddings, "HPV" and "hpv" are quite far apart, even though we want them to have the same representation.

Problem:
- When applying the custom glossary in KeyedVectorsScorer word look-up, we always look up the lowercased version of the token in the glossary

Solution:
- For now, when we initialize a KeyedVectorsScorer model or update its glossary using `.set_glossary(...)`, save all keys as their lowercase forms.

Notes
- Need to discuss whether this look-up should be case-sensitive, since sometimes lower and uppercase versions may have different meanings (e.g. "rat" vs. "RAT (Rapid Antigen Test)"